### PR TITLE
Add conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+name: dynagui
+channels:
+  - conda-forge
+  - tango-controls
+  - nodefaults
+dependencies:
+  - python
+  - numpy
+  - numexpr
+  - pyqtgraph
+  - matplotlib
+  - pyqt
+  - pyepics
+  - pandas
+  - pandas-datareader
+  - pytango


### PR DESCRIPTION
This PR tackles #3 and adds a conda environment file for an easier installation of the dependencies. I strongly recommend not to point to `pip` as many of the requirements of this repository cannot be safely installed using `pip` (`pytango`, for instance).

Note that the usage of this file should be explained in the `README` file. If you like, I can send write a little paragraph @benjaminbolling, but as the README file needs to be changed anyway (see #5), I did not do this here 